### PR TITLE
Create the tagger object only once and reuse it

### DIFF
--- a/src/pykatsuyou/pykatsuyou.py
+++ b/src/pykatsuyou/pykatsuyou.py
@@ -8,9 +8,7 @@ from .ichidan import Ichidan
 from .iAdj import IAdj
 from .irregulars import IrregularVerb
 
-tt = Tagger()
-
-def getInflections(text: str, jsonIndent: int = 0, dataframe:bool = False):
+def getInflections(text: str, jsonIndent: int = 0, dataframe: bool = False, tt: Tagger = Tagger()):
     """
     Get the inflections of a verb or adjective.
 

--- a/src/pykatsuyou/pykatsuyou.py
+++ b/src/pykatsuyou/pykatsuyou.py
@@ -8,6 +8,8 @@ from .ichidan import Ichidan
 from .iAdj import IAdj
 from .irregulars import IrregularVerb
 
+tt = Tagger()
+
 def getInflections(text: str, jsonIndent: int = 0, dataframe:bool = False):
     """
     Get the inflections of a verb or adjective.
@@ -46,7 +48,6 @@ def getInflections(text: str, jsonIndent: int = 0, dataframe:bool = False):
     EXCEPTIONS = ['入る', '走る', '要る', '帰る', '限る', '切る', '喋る', '知る', '湿る', 'しゃべる', '減る', '焦る', '蹴る', '滑る', '握る', '練る', '参る', '交じる', '嘲る', '覆る', '遮る', '罵る', '捻る', '翻る', '滅入る', '蘇る']
     IRREGULARS = ['する', '為る', 'くる', '来る']
 
-    tt = Tagger()
     check = tt.parse(text)
     posDivided = check[-1].feature.split(',') if len(check) > 0 else []
     


### PR DESCRIPTION
Recreating the tagger object (via `tt = Tagger()`) on every call of `getInflections` can cause too many open files if the user repeatedly calls the function. This is because each creation of the tagger object implies opening a file descriptor for the dictionary used by Igo for parsing the text.

This is what happened in this situation: https://github.com/precondition/Verb_inflections_JMDict/issues/1

The solution I propose is to add the tagger as an optional argument to `getInflections` which is set to `Tagger()` by default. This has the benefit of being backwards-compatible (since the argument is optional), fixing the `Too many open files` error (since the default value of an argument is the same instance of the object for every call in Python), and gives the users the possibility to instantiate their own `Tagger` object for use in PyKatsuyou in case they want to provide a more complete or up-to-date dictionary file (this would be useful to work around issues in the same vein as #2)